### PR TITLE
Device inprovement

### DIFF
--- a/inelsmqtt/const.py
+++ b/inelsmqtt/const.py
@@ -49,6 +49,7 @@ INELS_DEVICE_TYPE_DICT = {
 BATTERY = "battery"
 TEMP_IN = "temp_in"
 TEMP_OUT = "temp_out"
+TEMPERATURE = "temperature"
 CURRENT_TEMP = "current_temp"
 REQUIRED_TEMP = "required_temp"
 OPEN_IN_PERCENTAGE = "open_in_percentage"
@@ -135,7 +136,7 @@ CLIMATE_TYPE_09_DATA = {
     BATTERY: [2],
     REQUIRED_TEMP: [3],
 }
-DEVICE_TYPE_12_DATA = {TEMP_IN: [0], BATTERY: [2]}
+DEVICE_TYPE_12_DATA = {TEMPERATURE: [0], BATTERY: [2]}
 
 BUTTON_NUMBER = {
     "01": 1,

--- a/inelsmqtt/devices/__init__.py
+++ b/inelsmqtt/devices/__init__.py
@@ -7,12 +7,18 @@ from typing import Any
 from inelsmqtt.util import DeviceValue
 from inelsmqtt import InelsMqtt
 from inelsmqtt.const import (
+    BATTERY,
     DEVICE_TYPE_DICT,
     FRAGMENT_DOMAIN,
     INELS_DEVICE_TYPE_DICT,
     MANUFACTURER,
+    RFTC_10_G,
+    RFTI_10B,
     SENSOR,
     BUTTON,
+    TEMP_IN,
+    TEMP_OUT,
+    TEMPERATURE,
     TOPIC_FRAGMENTS,
     FRAGMENT_DEVICE_TYPE,
     FRAGMENT_SERIAL_NUMBER,
@@ -68,6 +74,7 @@ class Device(object):
         self.__domain = fragments[TOPIC_FRAGMENTS[FRAGMENT_DOMAIN]]
         self.__state: Any = None
         self.__values: DeviceValue = None
+        self.__features: dict[str] = self.__set_features(self.__inels_type)
 
         # subscribe availability
         self.__mqtt.subscribe(self.__connected_topic, 0, None, None)
@@ -194,6 +201,11 @@ class Device(object):
         """Instnace of broker."""
         return self.__mqtt
 
+    @property
+    def features(self) -> dict[str]:
+        """List of features of device."""
+        return self.__features
+
     def update_value(self, new_value: Any) -> DeviceValue:
         """Update value after broker change it."""
         return self.__get_value(new_value)
@@ -210,6 +222,17 @@ class Device(object):
         self.__values = dev_value
 
         return dev_value
+
+    def __set_features(self, inels_type: str) -> dict[str]:
+        """Set device features."""
+        features: dict[str] = None
+
+        if inels_type == RFTI_10B:
+            features = [TEMP_IN, TEMP_OUT, BATTERY]
+        elif inels_type == RFTC_10_G:
+            features = [TEMPERATURE, BATTERY]
+
+        return features
 
     def get_value(self) -> DeviceValue:
         """Get value from inels

--- a/inelsmqtt/util.py
+++ b/inelsmqtt/util.py
@@ -45,6 +45,7 @@ from .const import (
     SWITCH_WITH_TEMP_SET,
     TEMP_IN,
     TEMP_OUT,
+    TEMPERATURE,
 )
 
 ConfigType = Dict[str, str]
@@ -127,7 +128,7 @@ class DeviceValue(object):
                 )
             elif self.__inels_type is RFTC_10_G:
                 hex_temp = self.__trim_inels_status_values(
-                    DEVICE_TYPE_12_DATA, TEMP_IN, ""
+                    DEVICE_TYPE_12_DATA, TEMPERATURE, ""
                 )
                 hex_battery = self.__trim_inels_status_values(
                     DEVICE_TYPE_12_DATA, BATTERY, ""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="inels-mqtt",
-    version="0.0.52",
+    version="0.0.53",
     url="https://github.com/Nejezchleb/inels-mqtt",
     license="MIT",
     author="Elko EP s.r.o.",

--- a/tests/devices/device_test.py
+++ b/tests/devices/device_test.py
@@ -1,8 +1,6 @@
 """Unit tests for Device class
     handling device operations
 """
-from operator import itemgetter
-
 from unittest.mock import Mock, patch
 from unittest import TestCase
 from inelsmqtt import InelsMqtt
@@ -18,8 +16,6 @@ from inelsmqtt.const import (
     STATE_OPEN,
     STOP_UP,
     SWITCH,
-    TEMP_IN,
-    TEMP_OUT,
     DEVICE_TYPE_DICT,
     FRAGMENT_DEVICE_TYPE,
     FRAGMENT_DOMAIN,
@@ -29,7 +25,9 @@ from inelsmqtt.const import (
     SWITCH_ON_SET,
     SWITCH_ON_STATE,
     SWITCH_OFF_STATE,
-    DEVICE_TYPE_10_DATA,
+    TEMP_IN,
+    TEMP_OUT,
+    TEMPERATURE,
     TOPIC_FRAGMENTS,
     MQTT_HOST,
     MQTT_PORT,
@@ -245,7 +243,7 @@ class DeviceTest(TestCase):
         self.assertFalse(is_avilable)
 
     @patch(f"{TEST_INELS_MQTT_CLASS_NAMESPACE}.messages")
-    def test_temperature_parsing(self, mock_message) -> None:
+    def test_device_rfti_10b(self, mock_message) -> None:
         """Test parsing teperature data to relevant format."""
         mock_message.return_value = {TEST_SENSOR_TOPIC_STATE: TEST_TEMPERATURE_DATA}
 
@@ -259,8 +257,12 @@ class DeviceTest(TestCase):
         self.assertEqual(temp_out_decimal_result, data.temp_out)
         self.assertEqual(batter_decimal_result, data.battery)
 
+        self.assertIsNotNone(self.sensor.features)
+        self.assertEqual(len(self.sensor.features), 3)
+        self.assertEqual(self.sensor.features, [TEMP_IN, TEMP_OUT, BATTERY])
+
     @patch(f"{TEST_INELS_MQTT_CLASS_NAMESPACE}.messages")
-    def test_device_rftc_10_g(self, mock_message) -> None:
+    def test_device_rftc_10g(self, mock_message) -> None:
         """Test connectivity and data from device type 12."""
         mock_message.return_value = {
             TEST_SENSOR_RFTC_10_G_TOPIC_STATE: TEST_SENSOR_RFTC_10_G_STATE_VALUE
@@ -287,6 +289,10 @@ class DeviceTest(TestCase):
 
         self.assertEqual(temp, data.temperature)
         self.assertEqual(battery_level, data.battery)
+
+        self.assertIsNotNone(self.rftc_10_g.features)
+        self.assertEqual(len(self.rftc_10_g.features), 2)
+        self.assertEqual(self.rftc_10_g.features, [TEMPERATURE, BATTERY])
 
     @patch(f"{TEST_INELS_MQTT_CLASS_NAMESPACE}.messages")
     def test_device_dimmable_light_test_values(self, mock_message) -> None:


### PR DESCRIPTION
- Add feature list to the device object
-- features are set up when device is initializet based on the inels_type -- sensor device needs to have features because because HA will create each entity based on them